### PR TITLE
Add aws_kms_key_id to the output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "aws_kms_key_arn" {
   description = "The Amazon Resource Name (ARN) of the key."
   value       = aws_kms_key.sqs.arn
 }
+
+output "aws_kms_key_id" {
+  description = "The ID of the key."
+  value       = aws_kms_key.sqs.key_id
+}


### PR DESCRIPTION
I believe this is needed for use with the [kms_master_key_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue#kms_master_key_id) parameter in SQS Queues.